### PR TITLE
Add foreign key constraint delete test

### DIFF
--- a/RecipeApps/RecipeTest/RecipeTest.cs
+++ b/RecipeApps/RecipeTest/RecipeTest.cs
@@ -152,6 +152,10 @@ namespace RecipeTest
 
             Exception ex = Assert.Throws<Exception>(() => Recipe.Delete(dt));
             TestContext.WriteLine(ex.Message);
+            StringAssert.Contains("REFERENCE", ex.Message.ToUpper(), "should reach FK violation");
+
+            DataTable dtCheck = SQLUtility.GetDataTable("select * from recipe where recipeid = " + recipeid);
+            Assert.That(dtCheck.Rows.Count, Is.EqualTo(1), "recipe should still exist after failed delete");
         }
 
         [Test]

--- a/RecipeApps/RecipeTest/RecipeTest.cs
+++ b/RecipeApps/RecipeTest/RecipeTest.cs
@@ -137,11 +137,11 @@ namespace RecipeTest
             DataTable dt = SQLUtility.GetDataTable(@"select top 1 r.recipeid, r.recipename
                 from recipe r
                 left join recipemealcourse rmc
-                on rmc.recipeid = r.recipeid
+                    on rmc.recipeid = r.recipeid
                 left join cookbookrecipe cr
-                on cr.recipeid = r.recipeid
+                    on cr.recipeid = r.recipeid
                 where (r.recipestatus = 'draft'
-                    or DATEDIFF(DAY, r.datearchived, GETDATE()) >= 30)
+                    or DATEDIFF(DAY, r.datearchived, GETDATE()) < 30)
                     and (rmc.recipemealcourseid is not null
                         or cr.cookbookrecipeid is not null)");
 


### PR DESCRIPTION
## Summary
- extend tests with `DeleteRecipeWithForeignKeyConstraint` to ensure deletion fails when related records exist

## Testing
- `dotnet test RecipeApps/RecipeApps.sln --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68656980792c832da01bd5a58b448f45